### PR TITLE
Add support for -Si

### DIFF
--- a/pacman
+++ b/pacman
@@ -264,6 +264,10 @@ case "$_POPT$_SOPT" in
         _exec_ DPKG "apt-get remove $_PKG"
         _exec_ YUM  "yum erase $_PKG"
       ;;
+   "Si")
+        _exec_ DPKG "dpkg-query -s $_PKG"
+        _exec_ YUM  "yum info $_PKG"
+      ;;
   "Suy")
         _VERBOSE="" _exec_ DPKG "apt-get upgrade"
         _VERBOSE="" _exec_ DPKG "apt-get upgrade"


### PR DESCRIPTION
Technically, -Qi and -Si are different, in that -Qi shows information about the
locally-installed version, while -Si queries the repositories.  Unfortunately,
other distros don't seem to have this level of detail, as shown by the line in
the Pacman Rosetta, which lists `pacman -[S|Q]i` as one command.
