### PR TITLE
fix output of `ls` command for portage without gentoolkit

### DIFF
--- a/TODO
+++ b/TODO
@@ -2,7 +2,7 @@
 [x] For Gentoo system:
 
     pacman -Q       => eix -I
-    pacman -Qc <p>  => emerge -p --changlog <p>
+    pacman -Qc <p>  => emerge -p --changelog <p>
     pacman -Qi <p>  => emerge --info <p>
     pacmon -Ql <p>  => exists("qlist") && qlist <p> || equery files <p>
     pacman -Qm      = orphan packages, not supported

--- a/pacman
+++ b/pacman
@@ -384,7 +384,7 @@ case "$_POPT$_SOPT" in
             elif [ -x /usr/bin/equery ]; then
               equery list '*' $_PKG
             else
-              ls -d /var/db/pkg/*/*
+              LS_COLORS=never ls -1 -d /var/db/pkg/*/*
             fi
           "
       ;;

--- a/pacman
+++ b/pacman
@@ -190,7 +190,8 @@ case "$_OSTYPE" in
   "YUM"|"DPKG"|"HOMEBREW"|"PORTAGE")
     ;;
   *)
-    _error "No supported package manager (yum, apt, pacman, portage) installed on system"
+    _error "No supported package manager installed on system"
+    _error "(supported: apt, homebrew, pacman, portage, yum)"
     exit 1
     ;;
 esac


### PR DESCRIPTION
now generates output that is compatible (identical?) to others; one line per entry, no colorization

(also, note homebrew as a supported system on unsupported system error)
