### PR TITLE
Add --no-check-certificate to wget command

### DIFF
--- a/README
+++ b/README
@@ -30,7 +30,7 @@ INSTALL
 
   Download the script 'pacman' and install it into /usr/local/bin.
   Example:
-    $ wget https://github.com/icy/pacapt/raw/master/pacman -O /usr/local/bin/pacman
+    $ wget --no-check-certificate https://github.com/icy/pacapt/raw/master/pacman -O /usr/local/bin/pacman
     $ chmod 755 /usr/local/bin/pacman
 
   This script shouldn't be installed on an Arch-based system.


### PR DESCRIPTION
If you `wget` while checking the certificate, you get the following error:

```
ERROR: cannot verify github.com's certificate, issued by `/C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert High Assurance EV CA-1':
INFO -- :   Unable to locally verify the issuer's authority.
INFO -- : 16:12:23: To connect to github.com insecurely, use `--no-check-certificate'.
```
