### PR TITLE
Don't update cache on yum search.

### DIFF
--- a/pacman
+++ b/pacman
@@ -507,7 +507,7 @@ case "$_POPT$_SOPT" in
    "Ss")
         _exec_ DPKG     "apt-cache search $_PKG"
         _exec_ HOMEBREW "brew search $_PKG"
-        _exec_ YUM      "yum search $_PKG"
+        _exec_ YUM      "yum -C search $_PKG"
         _FORCE="" \
         _exec_ PORTAGE  "
             if [[ -x /usr/bin/eix ]]; then


### PR DESCRIPTION
By default, `yum search` will update the repositories' information.
Pacman does not do this, and requires you to do an -Sy operation first.
Since we've implemented -Sy for rpm-based systems, we can mimic that
behavior more closely by forcing yum to not update the cache when
searching (which is also faster).
