### PR TITLE
-Qo now works with relative pathnames on Homebrew

### DIFF
--- a/pacapt
+++ b/pacapt
@@ -367,11 +367,12 @@ case "$_POPT$_SOPT" in
 
         _exec_ DPKG     "dpkg-query -S $_PKG"
         _exec_ HOMEBREW "
+            cd \"$(dirname -- $(which $_PKG))\"
+            pkg=\"\$(pwd -P)/$(basename -- $_PKG)\"
             for package in /usr/local/Cellar/*; do
-              pkg=\"$_PKG\"
               files=(\${package}/*/\${pkg/#\/usr\/local\//})
               if [ -e \${files[\${#files[@]} - 1]} ]; then
-                echo \"\$package\"
+                echo \"\${package/#\/usr\/local\/Cellar\//}\"
                 break
               fi
             done


### PR DESCRIPTION
Paths such as `rust` or `/usr/local/bin/../bin/rust` now work in addition to `/usr/local/bin/rust`.
