### PR TITLE
Stop OS type warnings on Macs

### DIFF
--- a/pacapt
+++ b/pacapt
@@ -162,7 +162,9 @@ _OSTYPE_detect() {
   _found_arch ZYPPER "SUSE"
 
   if [[ -z "$_OSTYPE" ]]; then
-    _error "Can't detect OS type from /etc/issue. Running fallback method."
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+      _error "Can't detect OS type from /etc/issue. Running fallback method."
+    fi
     [[ -x "/usr/bin/pacman" ]]           && _OSTYPE="PACMAN"
     [[ -x "/usr/bin/apt-get" ]]          && _OSTYPE="DPKG"
     [[ -x "/usr/bin/yum" ]]              && _OSTYPE="YUM"


### PR DESCRIPTION
The warning is bothersome on Macs, as none of them have /etc/issue.  It should just be assumed that the fallback method is run when on a Mac.
