### PR TITLE
Homebrew: fix `ng` support

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -17,7 +17,7 @@ set -u
 set -e
 unset GREP_OPTIONS
 
-_SUPPORTED_PACMAN="(pkgng|dpkg|homebew|macports|portage|yum|zypper|cave)"
+_SUPPORTED_PACMAN="(pkgng|dpkg|homebrew|macports|portage|yum|zypper|cave)"
 
 VERSION="${VERSION:-$(git log --pretty="%h" -1 2>/dev/null)}"
 VERSION="${VERSION:-unknown}"


### PR DESCRIPTION
This week I decided to try out the `ng` branch of pacapt, but noticed nothing
seemed to work with homebrew:

```
[$]> ./compile.sh > pacapt.dev && ./pacapt.dev -Ss foo
pacapt version 'a411f26' has been generated
homebrew: 'S:s:' operation is invalid or not implemented.
```

A little bit of investigation showed it was due to a typo in the name
'homebrew', causing none of the defined functions to match the grep and end up
in `_validate_operation()`'s list.

With this patch, everything operates as expected:

```
[$]> ./compile.sh > pacapt.dev && ./pacapt.dev -Ss foo
pacapt version 'a411f26' has been generated
No formula found for "foo".
Searching pull requests...
Closed pull requests:
Blacklist foo to prevent terrible bug reports (https://github.com/Homebrew/homebrew/pull/18002)
```
