### PR TITLE
Fix invokation to _die

### DIFF
--- a/lib/zz_main.sh
+++ b/lib/zz_main.sh
@@ -22,7 +22,7 @@ _EOPT="" # extra options (directly given to package manager)
 _PACMAN="" # name of the package manager
 
 _PACMAN_detect \
-|| die "'pacapt' doesn't support your package manager."
+|| _die "'pacapt' doesn't support your package manager."
 
 if [[ -z "$PACAPT_DEBUG" ]]; then
   [[ "$_PACMAN" != "pacman" ]] \


### PR DESCRIPTION
zz_master.sh has one call to die instead of _die which causes pacapt to misbehave.
