### PR TITLE
OpenBSD pkg_tools support

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Purpose: A wrapper for all Unix package managers
 # Author : Anh K. Huynh
@@ -17,7 +17,7 @@ set -u
 set -e
 unset GREP_OPTIONS
 
-_SUPPORTED_PACMAN="(pkgng|dpkg|homebrew|macports|portage|yum|zypper|cave)"
+_SUPPORTED_PACMAN="(pkgng|dpkg|homebrew|macports|portage|yum|zypper|cave|pkg_tools)"
 
 VERSION="${VERSION:-$(git log --pretty="%h" -1 2>/dev/null)}"
 VERSION="${VERSION:-unknown}"

--- a/lib/00_core.sh
+++ b/lib/00_core.sh
@@ -49,6 +49,8 @@ _PACMAN_detect() {
   _issue2pacman yum "Red Hat" && return
   _issue2pacman yum "Fedora" && return
   _issue2pacman zypper "SUSE" && return
+  _issue2pacman pkg_tools "OpenBSD" && return
+  _issue2pacman pkg_tools "Bitrig" && return
 
   [[ -z "$_PACMAN" ]] || return
 
@@ -66,6 +68,8 @@ _PACMAN_detect() {
   [[ -x "/usr/bin/emerge" ]] && _PACMAN="portage" && return
   [[ -x "/usr/bin/zypper" ]] && _PACMAN="zypper" && return
   [[ -x "/usr/sbin/pkg" ]] && _PACMAN="pkgng" && return
+  # make sure pkg_add is after pkgng, FreeBSD base comes with it until converted
+  [[ -x "/usr/sbin/pkg_add" ]] && _PACMAN="pkg_tools" && return
 
   command -v brew >/dev/null && _PACMAN="homebrew" && return
 

--- a/lib/pkg_tools.sh
+++ b/lib/pkg_tools.sh
@@ -1,0 +1,115 @@
+# Purpose: OpenBSD support
+# Author : Somasis <somasissounds@gmail.com>
+# License: Fair license (http://www.opensource.org/licenses/fair)
+# Source : http://github.com/somasis/pacapt
+
+# Copyright (C) 2014 Somasis
+#
+# Usage of the works is permitted provided that this instrument is
+# retained with the works, so that any entity that uses the works is
+# notified of this instrument.
+#
+# DISCLAIMER: THE WORKS ARE WITHOUT WARRANTY.
+
+_pkg_tools_init() {
+  :
+}
+
+pkg_tools_Qi() {
+  PKG_PATH= # disable searching mirrors for packages
+  pkg_info "$@"
+}
+
+pkg_tools_Ql() {
+  PKG_PATH=
+  pkg_info -L "$@"
+}
+
+pkg_tools_Qo() {
+  PKG_PATH=
+  pkg_info -E "$@"
+}
+
+pkg_tools_Qp() {
+  _not_implemented
+}
+
+pkg_tools_Qu() {
+  PKG_PATH=
+  pkg_add -nUuI "$@"
+}
+
+pkg_tools_Q() {
+  PKG_PATH=
+  # the dash after the pkg name is so we don't catch partial matches
+  # because all packages in openbsd have the format 'pkgname-pkgver'
+  if [[ "$_TOPT" == "q" ]]; then
+    pkg_info -q | grep "^$@-"
+  elif [[ "$_TOPT" == "" ]]; then
+    pkg_info | grep "^$@-"
+  else
+    _not_implemented
+  fi
+}
+
+pkg_tools_Rs() {
+  if [[ "$_TOPT" == "" ]]; then
+    pkg_delete -D dependencies "$@"
+  else
+    _not_implemented
+  fi
+}
+
+pkg_tools_R() {
+  pkg_delete "$@"
+}
+
+pkg_tools_Si() {
+  pkg_info "$@"
+}
+
+pkg_tools_Suy() {
+  # pkg_tools doesn't really have any concept of a database
+  # there's actually not really any database to update, so
+  # this function is mostly just for convienience since on arch
+  # doing -Su is normally a bad thing to do since it's a partial upgrade
+
+  pkg_add -u "$@"
+}
+
+pkg_tools_Su() {
+  pkg_add -u "$@"
+}
+
+pkg_tools_Sy() {
+  _not_implemented
+}
+
+pkg_tools_Ss() {
+  pkg_info -Q "$@"
+}
+
+pkg_tools_Sc() {
+  # by default no cache directory is used
+  if [[ -z "$PKG_CACHE" ]];then
+    echo "You have no cache directory set, set \$PKG_CACHE for a cache directory."
+  else
+    cd "$PKG_CACHE"
+    if [[ "$_TOPT" != "--noconfirm" ]];then
+      # dont't blindly delete everything in a directory!
+      rm -irf *
+    else
+      # unless they really want to...
+      rm -rf *
+    fi
+  fi
+
+}
+
+pkg_tools_Scc() {
+  _not_implemented
+}
+
+pkg_tools_S() {
+  pkg_add "$@"
+}


### PR DESCRIPTION
This adds support for `pkg_add`, `pkg_delete`, `pkg_info`, etc on OpenBSD, collectively known as `pkg_tools`.

In addition, I solved a bug found while trying to use it on OpenBSD, which is the shebang used on the scripts. Using `#!/bin/bash` on OpenBSD (and confirmed on FreeBSD, actually) doesn't work, because it's installed to /usr/local/bin/bash; so, `#!/usr/bin/env bash` is used instead, which should be compatible with just about any common *nix system.

I've tested it on my OpenBSD server, so it should be fine.
