### PR TITLE
Add safety checks to pkg_tools cache clearing

### DIFF
--- a/lib/pkg_tools.sh
+++ b/lib/pkg_tools.sh
@@ -117,8 +117,10 @@ pkg_tools_Sc() {
   # by default no cache directory is used
   if [[ -z "$PKG_CACHE" ]];then
     echo "You have no cache directory set, set \$PKG_CACHE for a cache directory."
+  elif [[ ! -d "$PKG_CACHE" ]];then
+  	  echo "You have a cache directory set, but it does not exist. Create \"$PKG_CACHE\"."
   else
-    cd "$PKG_CACHE"
+    cd "$PKG_CACHE" || exit $?
     if [[ "$_TOPT" != "--noconfirm" ]];then
       # don't blindly delete everything in a directory!
       rm -irf *
@@ -137,3 +139,4 @@ pkg_tools_Scc() {
 pkg_tools_S() {
   pkg_add "$@"
 }
+


### PR DESCRIPTION
I made this a new pull request for the sake of not committing too much in one request. These were the cache safety checks I talked about, but I apparently forgot to push them.

Anyway, this adds some simple checks. If `$PKG_CACHE` is set, but it's value is not actually a directory, it will tell you to make it, and then exits. Otherwise, it will continue trying to `cd` into it, failing and exiting with a non-zero code if it can not change to it's directory. There is not much else that can be done in terms of safety checks, since the guidelines for what constitutes a valid `$PKG_CACHE` in pkg_tools is fairly liberal.
