### PR TITLE
Homebrew: fix -Su and -Scc

### DIFF
--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -79,7 +79,7 @@ homebrew_Suy() {
 }
 
 homebrew_Su() {
-  bre upgrade "$@"
+  brew upgrade "$@"
 }
 
 homebrew_Sy() {
@@ -95,7 +95,7 @@ homebrew_Sc() {
 }
 
 homebrew_Scc() {
-  bre cleanup -s "$@"
+  brew cleanup -s "$@"
 }
 
 homebrew_Sccc() {


### PR DESCRIPTION
Both of these were missing a 'w' in the `brew` command, which caused them to
fail.
