### PR TITLE
Fix bug forgetting quote PACAPT_DEBUG.

### DIFF
--- a/lib/zz_main.sh
+++ b/lib/zz_main.sh
@@ -13,7 +13,7 @@
 
 set -u
 unset GREP_OPTIONS
-: ${PACAPT_DEBUG=}
+: "${PACAPT_DEBUG=}"
 
 _POPT="" # primary operation
 _SOPT="" # secondary operation


### PR DESCRIPTION
Forgetting quote variables in shell script leading to many security implications. This pull request fix an issue can make DOS/DDOS attack to machine which run pacapt. Example:

```
PACAPT_DEBUG='/*/*/*/*/../../../../*/*/*/*/../../../../*/*/*/*' ./pacapt --help
```
