### PR TITLE
Homebrew: add --all flag to upgrade

### DIFF
--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -83,11 +83,11 @@ homebrew_Si() {
 
 homebrew_Suy() {
   brew update \
-  && brew upgrade "$@"
+  && brew upgrade --all "$@"
 }
 
 homebrew_Su() {
-  brew upgrade "$@"
+  brew upgrade --all "$@"
 }
 
 homebrew_Sy() {


### PR DESCRIPTION
Per Homebrew/homebrew#38572, homebrew is migrating to require the `--all` flag
for upgrade operations.
