### PR TITLE
Revise _has_shellcheck:

### DIFF
--- a/bin/check.sh
+++ b/bin/check.sh
@@ -64,8 +64,7 @@ _shellcheck_output_format() {
 }
 
 _has_shellcheck() {
-  shellcheck -V 2>/dev/null \
-  | grep http://www.shellcheck.net -q
+  command -v shellcheck >/dev/null 2>&1
 }
 
 _check_file() {


### PR DESCRIPTION
- POSIX shell provided `command -v cmd` to check if cmd is available.
- Calling `shellcheck` directly with `grep` cost us 2 processes with
  nothing better than standard one.
- `grep pattern -q` won't work in system other than GNU/Linux.
