### PR TITLE
Add dnf support

### DIFF
--- a/lib/00_core.sh
+++ b/lib/00_core.sh
@@ -66,7 +66,7 @@ _PACMAN_detect() {
   _issue2pacman cave "Exherbo Linux" && return
   _issue2pacman yum "CentOS" && return
   _issue2pacman yum "Red Hat" && return
-  _issue2pacman yum "Fedora" && return
+#  _issue2pacman yum "Fedora" && return
   _issue2pacman zypper "SUSE" && return
   _issue2pacman pkg_tools "OpenBSD" && return
   _issue2pacman pkg_tools "Bitrig" && return
@@ -82,6 +82,7 @@ _PACMAN_detect() {
 
   [[ -x "/usr/bin/apt-get" ]] && _PACMAN="dpkg" && return
   [[ -x "/usr/bin/cave" ]] && _PACMAN="cave" && return
+  [[ -x "/usr/bin/dnf" ]] && _PACMAN="dnf" && return
   [[ -x "/usr/bin/yum" ]] && _PACMAN="yum" && return
   [[ -x "/opt/local/bin/port" ]] && _PACMAN="macports" && return
   [[ -x "/usr/bin/emerge" ]] && _PACMAN="portage" && return
@@ -150,6 +151,7 @@ _translate_noconfirm() {
   # FIXME: Update environment DEBIAN_FRONTEND=noninteractive
   # FIXME: There is also --force-yes for a stronger case
   "dpkg")   _opt="--yes";;
+  "dnf")    _opt="--assumeyes";;
   "yum")    _opt="--assumeyes";;
   # FIXME: pacman has 'assume-yes' and 'assume-no'
   # FIXME: zypper has better mode. Similar to dpkg (Debian).

--- a/lib/dnf.sh
+++ b/lib/dnf.sh
@@ -1,5 +1,108 @@
 #!/bin/bash
 
+# Purpose: Support next-generation Yum package manager 
+# Author : Severus <severus@theslinux.org>
+# License: Fair license (http://www.opensource.org/licenses/fair)
+# Source : http://github.com/icy/pacapt/
+
+# Copyright (C) 2015 Severus
+#
+# Usage of the works is permitted provided that this instrument is
+# retained with the works, so that any entity that uses the works is
+# notified of this instrument.
+#
+# DISCLAIMER: THE WORKS ARE WITHOUT WARRANTY.
+
+_dnf_init() {
+  :
+}
+
 dnf_S() {
   dnf install $_TOPT "$@"
+}
+
+dnf_Suy() {
+  dnf upgrade "$@"
+}
+
+dnf_Sw() {
+  dnf download "$@"
+}
+
+dnf_Si() {
+  dnf info "$@"
+}
+
+dnf_Sl() {
+  dnf list available "$@"
+}
+
+dnf_Ss() {
+  dnf search "$@"
+}
+
+dnf_Sc() {
+  dnf clean expire-cache "$@"
+}
+
+dnf_Scc() {
+   dnf clean packages "$@"
+}
+
+dnf_Sccc() {
+    dnf clean all "$@"
+}
+
+dnf_Su() {
+  dnf upgrade "$@"
+}
+
+dnf_Sy() {
+  dnf clean expire-cache && dnf check-update
+}
+
+dnf_Q() {
+  if [[ "$_TOPT" == "q" ]]; then
+    rpm -qa --qf "%{NAME}\n"
+  elif [[ "$_TOPT" == "" ]]; then
+    rpm -qa --qf "%{NAME} %{VERSION}\n"
+  else
+    _not_implemented
+  fi
+}
+
+dnf_Qi() {
+  dnf info "$@"
+}
+
+dnf_Qu() {
+  dnf list updates "$@"
+}
+
+dnf_Ql() {
+  rpm -ql "$@"
+}
+
+dnf_Qo() {
+  rpm -qf "$@"
+}
+
+dnf_Qp() {
+  rpm -qp "$@"
+}
+
+dnf_Qc() {
+  rpm -q --changelog "$@"
+}
+
+dnf_Qm() {
+  dnf list extras
+}
+
+dnf_R() {
+  dnf remove "$@"
+}
+
+dnf_U() {
+  dnf install "$@"
 }


### PR DESCRIPTION
Because both `dnf` and `yum` exist, we remove checking base on distro
name and order binary checking.
