### PR TITLE
fix typographical error

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ sudo chmod 755 /usr/local/bin/pacapt
 $ sudo ln -sv /usr/local/bin/pacapt /usr/local/bin/pacman || true
 ````
 
-This scrip is actually picked from the latest stable branch,
+This script is actually picked from the latest stable branch,
 which is `v2.0` at the moment. If you want to compile a script
 from its components, please make sure you use a correct branch.
 See `CONTRIBUTING.md` for details.


### PR DESCRIPTION
Hey there,

amazing project! A huge hit with my Arch GNU/Linux compatriots. Many thanks for your effort here.

I noticed today a slight typo that wouldn't have been picked up by a spell-checker, as the mis-typed word is also valid in English.

I hope I'm submitting this to the right branch; please let me know if anything is out of place. 

Cheers,
esc
