### PR TITLE
Make _EOPT to be sane

### DIFF
--- a/lib/00_core.sh
+++ b/lib/00_core.sh
@@ -172,12 +172,14 @@ _translate_noconfirm() {
 
 _translate_all() {
   local _args=""
+  local _debug="$(_translate_debug)"
+  local _noconfirm="$(_translate_noconfirm)"
 
   _args="$(_translate_w)" || return 1
-  _args="${_args:+$_args }$(_translate_noconfirm)" || return 1
-  _args="${_args:+$_args }$(_translate_debug)" || return 1
+  _args="${_args}${_noconfirm:+ }${_noconfirm}" || return 1
+  _args="${_args}${_debug:+ }${_debug}" || return 1
 
-  export _EOPT="$_args"
+  export _EOPT="${_args# }"
 }
 
 _print_supported_operations() {

--- a/lib/apk.sh
+++ b/lib/apk.sh
@@ -64,10 +64,10 @@ apk_Rs() {
 
 apk_S() {
   case ${_EOPT} in
-    # Download only, _translate_w gave trailing spaces
-    ("fetch "*) shift
-                apk fetch        -- "$@" ;;
-            (*) apk add   $_TOPT -- "$@" ;;
+    # Download only
+    ("fetch") shift
+              apk fetch        -- "$@" ;;
+          (*) apk add   $_TOPT -- "$@" ;;
   esac
 }
 


### PR DESCRIPTION
Currently, `_translate_all` gave us `_EOPT` with trailing spaces.

On GNU systems, we can use `PACAPT_DEBUG=auto pacapt ... | cat -et` to see what `_EOPT` contains. But it's hard on systems without GNU tools.

This pull try to make `_EOPT` to be saner. If one option, like download, provided, then `_EOPT` won't have trailing spaces.
