### PR TITLE
Implement -Qs for rpm (yum & dnf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A short description can be found at
 pkg_tools  y  .  y  y  .  y  y  .  y y  y   y  y y  y   y    .  y   .  y  y  y   y  .  y .
   portage  y  y  y  y  .  y  .  .  y y  .   .  y y  y   y    y  y   .  .  y  y   y  .  y .
 sun_tools  y  .  y  y  .  y  .  y  . y  .   .  . .  .   .    .  .   .  .  .  .   .  .  . y
-      yum  y  y  y  y  y  y  y  .  y y  .   .  y y  y   y    y  y   y  .  y  y   y  .  y y
+      yum  y  y  y  y  y  y  y  y  y y  .   .  y y  y   y    y  y   y  .  y  y   y  .  y y
    zypper  y  y  y  y  y  y  y  y  y y  y   y  y y  y   y    y  y   y  y  y  y   y  .  y y
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ A short description can be found at
            Q Qc Qi Ql Qm Qo Qp Qs Qu R Rn Rns Rs S Sc Scc Sccc Si Sii Sl Ss Su Suy Sw Sy U
       apk  y  .  y  y  .  y  .  y  y y  y   y  y y  y   y    y  y   y  y  y  y   y  y  y y
      cave  y  .  y  y  .  y  y  y  y y  y   y  y y  y   y    y  y   .  .  y  y   y  .  y y
-      dnf  y  y  y  y  y  y  y  .  y y  .   .  . y  y   y    y  y   .  y  y  y   y  y  y y
+      dnf  y  y  y  y  y  y  y  y  y y  .   .  . y  y   y    y  y   .  y  y  y   y  y  y y
      dpkg  y  .  y  y  .  y  y  y  y y  y   y  y y  y   y    y  y   y  .  y  y   y  .  y y
  homebrew  y  y  y  y  .  y  .  y  y y  .   .  y y  y   y    y  y   .  .  y  y   y  .  y .
  macports  .  y  .  y  .  y  .  .  y y  .   .  y y  y   y    .  y   .  .  y  y   y  .  y .

--- a/lib/dnf.sh
+++ b/lib/dnf.sh
@@ -79,6 +79,10 @@ dnf_Qu() {
   dnf list updates "$@"
 }
 
+dnf_Qs() {
+  rpm -qa "*$@*"
+}
+
 dnf_Ql() {
   rpm -ql "$@"
 }

--- a/lib/yum.sh
+++ b/lib/yum.sh
@@ -31,6 +31,10 @@ yum_Qi() {
   yum info "$@"
 }
 
+yum_Qs() {
+  rpm -qa "*$@*"
+}
+
 yum_Ql() {
   rpm -ql "$@"
 }


### PR DESCRIPTION
Based on the Pacman Rosetta Stone https://wiki.archlinux.org/index.php/Pacman/Rosetta

To mimic pacman's behaviour, this pads the search string with asterisks so that rpm will return more than just whole-word matches.
Tested on Centos 6 and works as expected.

I also ticked the Yum/Qs field with `y` in the README.
Just let me know if there's anything I missed.
