### PR TITLE
remove --all from brew upgrade

### DIFF
--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -88,11 +88,11 @@ homebrew_Si() {
 
 homebrew_Suy() {
   brew update \
-  && brew upgrade --all "$@"
+  && brew upgrade "$@"
 }
 
 homebrew_Su() {
-  brew upgrade --all "$@"
+  brew upgrade "$@"
 }
 
 homebrew_Sy() {


### PR DESCRIPTION
The current version of **homebrew** (see below) does not need the `--all` argument for `upgrade`. See the warning message below (shown when you run `upgrade` with the `--all` argument).

Version
--------

Homebrew 1.1.10-3191-gfa34aa2
Homebrew/homebrew-core (git revision a176; last commit 2017-02-28)

Warning message 
------------------

Warning: We decided to not change the behaviour of `brew upgrade` so
`brew upgrade --all` is equivalent to `brew upgrade` without any other
arguments (so the `--all` is a no-op and can be removed).