### PR TITLE
Change `brew upgrade --all` to `brew upgrade`

### DIFF
--- a/pacapt
+++ b/pacapt
@@ -892,11 +892,11 @@ homebrew_Si() {
 
 homebrew_Suy() {
   brew update \
-  && brew upgrade --all "$@"
+  && brew upgrade "$@"
 }
 
 homebrew_Su() {
-  brew upgrade --all "$@"
+  brew upgrade "$@"
 }
 
 homebrew_Sy() {


### PR DESCRIPTION
From Homebrew:
```
Warning: We decided to not change the behaviour of `brew upgrade` so
`brew upgrade --all` is equivalent to `brew upgrade` without any other
arguments (so the `--all` is a no-op and can be removed).
```