### PR TITLE
Fix tlmgr support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,15 @@ A short description can be found at
      cave  *     *     *     *  *  *  * *  *   *  * *  *   *    x  *         *  *   *     * x
       dnf  ~  *  *     *  *  *  *  *  * *           *  *   *    *  *      *  *  *   *  *  * *
      dpkg  ~     *     *     *  *  *  * *  *   *  ~ *  *   *    *  *   *     *  *   *     * *
- homebrew  ~  *  *     *     *     *  * *         * *  *   *    *  *         *  *   *     *
- macports     *        *     *        * *         ~ *  *   *       *         *  *   *     *
-    pkgng  *     *     *     *  *     * *         * *  *   *       *         *  *   *     *
-pkg_tools  ~     *     *     *  *     * *  *   *  ~ *  *   x       *      *  ~  *   *     x
-  portage  *  *  *     *     *        * *         * *  *   *    *  *         *  *   *     *
+ homebrew  ~  *  *     *     *     *  * *         * *  *   *    *  *         *  *   *     *  
+ macports     *        *     *        * *         ~ *  *   *       *         *  *   *     *  
+    pkgng  *     *     *     *  *     * *         * *  *   *       *         *  *   *     *  
+pkg_tools  ~     *     *     *  *     * *  *   *  ~ *  *   x       *      *  ~  *   *     x  
+  portage  *  *  *     *     *        * *         * *  *   *    *  *         *  *   *     *  
 sun_tools  *     *     *     *     *    *                                                   *
-    swupd           *        *     *    *           *                        *  *   *     *
+    swupd           *        *     *    *           *                        *  *   *     *  
    tazpkg  *     *     *     *          *           *  *   *                 *  *   *     * *
-    tlmgr        *  *              *    *           *              *         *      *       *
+    tlmgr        *  *  *                *           *              *         *      *       *
       yum  *  *  *     *  *  *  *  *  * *         * *  *   *    *  *   *     *  *   *     * *
    zypper  *  *  *     *  *  *  *  *  * *  *   *  * *  *   *    *  *   *  *  *  *   *  *  * *
 ```

--- a/lib/tlmgr.sh
+++ b/lib/tlmgr.sh
@@ -25,12 +25,8 @@ tlmgr_Qk() {
   tlmgr check files
 }
 
-tlmgr_Qs() {
-  tlmgr search --only-installed --list "$@"
-}
-
-tlmgr_Qs() {
-  tlmgr search --only-installed "$@"
+tlmgr_Ql() {
+  tlmgr info --only-installed --list "$@"
 }
 
 tlmgr_R() {


### PR DESCRIPTION
xref https://github.com/icy/pacapt/pull/107#issuecomment-409884574
Sorry, that implementation was -Ql, not -Qs.  In fact `search` doesn't take `--only-installed`, I'll need to revisit that... (removed it for now)