### PR TITLE
adding dist-upgrade for dpkg to dpkg_Suy and dpkg_Su functions

### DIFF
--- a/lib/dpkg.sh
+++ b/lib/dpkg.sh
@@ -105,11 +105,13 @@ dpkg_Si() {
 
 dpkg_Suy() {
   apt-get update \
-  && apt-get upgrade "$@"
+  && apt-get upgrade "$@" \
+  && apt-get dist-upgrade "$@"
 }
 
 dpkg_Su() {
-  apt-get upgrade "$@"
+  apt-get upgrade "$@" \
+  && apt-get dist-upgrade "$@"
 }
 
 # See also https://github.com/icy/pacapt/pull/78

--- a/pacapt
+++ b/pacapt
@@ -923,11 +923,13 @@ dpkg_Si() {
 
 dpkg_Suy() {
   apt-get update \
-  && apt-get upgrade "$@"
+  && apt-get upgrade "$@" \
+  && apt-get dist-upgrade "$@"
 }
 
 dpkg_Su() {
-  apt-get upgrade "$@"
+  apt-get upgrade "$@" \
+  && apt-get dist-upgrade "$@"
 }
 
 


### PR DESCRIPTION
Adding apt-get dist-upgrade to the dpkg wrapper functions Suy and Su because it is very annoying that not all packages are updated on only apt-get upgrade

Changes where tested on Ubuntu and Debian