### PR TITLE
Homebrew -Rs implementation

### DIFF
--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -69,12 +69,12 @@ homebrew_Q() {
 }
 
 homebrew_Rs() {
-    join
+    which join > /dev/null
     if [ $? -ne 0 ]; then
       _error "${FUNCNAME[0]}: join binary does not exist in system."
     fi
 
-    sort
+    which sort > /dev/null
     if [ $? -ne 0 ]; then
       _error "${FUNCNAME[0]}: sort binary does not exist in system."
     fi

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -71,13 +71,13 @@ homebrew_Q() {
 homebrew_Rs() {
     which join > /dev/null
     if [ $? -ne 0 ]; then
-      _error "${FUNCNAME[0]}: join binary does not exist in system."
+      _error "pacapt: join binary does not exist in system."
       return 1
     fi
 
     which sort > /dev/null
     if [ $? -ne 0 ]; then
-      _error "${FUNCNAME[0]}: sort binary does not exist in system."
+      _error "pacapt: sort binary does not exist in system."
       return 1
     fi
 

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -71,14 +71,12 @@ homebrew_Q() {
 homebrew_Rs() {
     which join > /dev/null
     if [ $? -ne 0 ]; then
-      _error "pacapt: join binary does not exist in system."
-      return 1
+      _die "pacapt: join binary does not exist in system."
     fi
 
     which sort > /dev/null
     if [ $? -ne 0 ]; then
-      _error "pacapt: sort binary does not exist in system."
-      return 1
+      _die "pacapt: sort binary does not exist in system."
     fi
 
     brew rm "$@"

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -74,7 +74,7 @@ homebrew_Q() {
 homebrew_Rs() {
   if [[ "$_TOPT" == "s" ]]; then
     brew rm "$@"
-    brew rm $(join <(brew leaves) <(brew deps "$@"))
+    brew rm $(join <(sort <(brew leaves)) <(sort <(brew deps "$@")))
   else
     _not_implemented
   fi

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -72,11 +72,13 @@ homebrew_Rs() {
     which join > /dev/null
     if [ $? -ne 0 ]; then
       _error "${FUNCNAME[0]}: join binary does not exist in system."
+      return 1
     fi
 
     which sort > /dev/null
     if [ $? -ne 0 ]; then
       _error "${FUNCNAME[0]}: sort binary does not exist in system."
+      return 1
     fi
 
     brew rm "$@"

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -70,14 +70,9 @@ homebrew_Q() {
 
 # FIXME: make sure "join" does exit
 # FIXME: Add quoting support, be cause "join" can fail
-# homebew_Rs may _not_implemented
 homebrew_Rs() {
-  if [[ "$_TOPT" == "s" ]]; then
     brew rm "$@"
     brew rm $(join <(sort <(brew leaves)) <(sort <(brew deps "$@")))
-  else
-    _not_implemented
-  fi
 }
 
 homebrew_R() {

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -82,7 +82,11 @@ homebrew_Rs() {
     fi
 
     brew rm "$@"
-    brew rm $(join <(sort <(brew leaves)) <(sort <(brew deps "$@")))
+
+    while [ "$(join <(sort <(brew leaves)) <(sort <(brew deps "$@")))" != "" ]
+    do
+      brew rm $(join <(sort <(brew leaves)) <(sort <(brew deps "$@")))
+    done
 }
 
 homebrew_R() {

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -68,9 +68,17 @@ homebrew_Q() {
   fi
 }
 
-# FIXME: make sure "join" does exit
-# FIXME: Add quoting support, be cause "join" can fail
 homebrew_Rs() {
+    join
+    if [ $? -ne 0 ]; then
+      _error "${FUNCNAME[0]}: join binary does not exist in system."
+    fi
+
+    sort
+    if [ $? -ne 0 ]; then
+      _error "${FUNCNAME[0]}: sort binary does not exist in system."
+    fi
+
     brew rm "$@"
     brew rm $(join <(sort <(brew leaves)) <(sort <(brew deps "$@")))
 }

--- a/lib/homebrew.sh
+++ b/lib/homebrew.sh
@@ -79,12 +79,20 @@ homebrew_Rs() {
       _die "pacapt: sort binary does not exist in system."
     fi
 
-    brew rm "$@"
+    if [[ "$@" == "" ]]; then
+      _die "pacapt: ${FUNCNAME[0]} requires arguments"
+    fi
 
-    while [ "$(join <(sort <(brew leaves)) <(sort <(brew deps "$@")))" != "" ]
+    for _target in $@;
     do
-      brew rm $(join <(sort <(brew leaves)) <(sort <(brew deps "$@")))
+      brew rm $_target
+
+      while [ "$(join <(sort <(brew leaves)) <(sort <(brew deps $_target)))" != "" ]
+      do
+        brew rm $(join <(sort <(brew leaves)) <(sort <(brew deps $_target)))
+      done
     done
+
 }
 
 homebrew_R() {


### PR DESCRIPTION
Since current pacapt does not support -Rs as mentioned in issue #123, I made some fixes in lib/homebrew.sh as follows:

- Removed _TOPT check which always leads to _not_implemented
- Sort `brew leaves` and `brew deps` output, sometimes they are not sorted enough to `join`
- Check if sort/join binary exists (....which relies on `which`)
- Multiple argument support
