### PR TITLE
Small improvements to dnf support.

### DIFF
--- a/lib/dnf.sh
+++ b/lib/dnf.sh
@@ -34,7 +34,7 @@ dnf_Sccc() {
 }
 
 dnf_Si() {
-  dnf info "$@"
+  dnf info "$@" && dnf repoquery --deplist "$@"
 }
 
 dnf_Sg() {
@@ -89,7 +89,7 @@ dnf_Qe() {
 }
 
 dnf_Qi() {
-  dnf info "$@"
+  dnf info --installed "$@" && dnf repoquery --deplist "$@"
 }
 
 dnf_Ql() {


### PR DESCRIPTION
- Differentiate -Si and -Qi by making the latter only support locally
  installed packages (as pacman does).
- Include list of dependencies in the output of -Si/-Qi (as pacman
  does).