### PR TITLE
lib/*: _Qo first tries binary searching. Fix #141

### DIFF
--- a/lib/apk.sh
+++ b/lib/apk.sh
@@ -36,7 +36,11 @@ apk_Ql() {
 }
 
 apk_Qo() {
-  apk info --who-owns -- "$@"
+  if cmd="$(command -v -- "$@")"; then
+    apk info --who-owns -- "$cmd"
+  else
+    apk info --who-owns -- "$@"
+  fi
 }
 
 apk_Qs() {

--- a/lib/cave.sh
+++ b/lib/cave.sh
@@ -49,7 +49,11 @@ cave_Ql() {
 }
 
 cave_Qo() {
-  cave owner "$@"
+  if cmd="$(command -v -- "$@")"; then
+    cave owner "$cmd"
+  else
+    cave owner "$@"
+  fi
 }
 
 cave_Qp() {

--- a/lib/dnf.sh
+++ b/lib/dnf.sh
@@ -101,7 +101,11 @@ dnf_Qm() {
 }
 
 dnf_Qo() {
-  rpm -qf "$@"
+  if cmd="$(command -v -- "$@")"; then
+    rpm -qf "$cmd"
+  else
+    rpm -qf "$@"
+  fi
 }
 
 dnf_Qp() {

--- a/lib/dpkg.sh
+++ b/lib/dpkg.sh
@@ -57,7 +57,11 @@ dpkg_Ql() {
 }
 
 dpkg_Qo() {
-  dpkg-query -S "$@"
+  if cmd="$(command -v -- "$@")"; then
+    dpkg-query -S "$cmd"
+  else
+    dpkg-query -S "$@"
+  fi
 }
 
 dpkg_Qp() {

--- a/lib/macports.sh
+++ b/lib/macports.sh
@@ -22,7 +22,11 @@ macports_Ql() {
 }
 
 macports_Qo() {
-  port provides "$@"
+  if cmd="$(command -v -- "$@")"; then
+    port provides "$cmd"
+  else
+    port provides "$@"
+  fi
 }
 
 macports_Qc() {

--- a/lib/pkg_tools.sh
+++ b/lib/pkg_tools.sh
@@ -30,7 +30,11 @@ pkg_tools_Ql() {
 
 pkg_tools_Qo() {
   export PKG_PATH=
-  pkg_info -E "$@"
+  if cmd="$(command -v -- "$@")"; then
+    pkg_info -E "$cmd"
+  else
+    pkg_info -E "$@"
+  fi
 }
 
 pkg_tools_Qp() {

--- a/lib/pkgng.sh
+++ b/lib/pkgng.sh
@@ -31,7 +31,11 @@ pkgng_Ql() {
 }
 
 pkgng_Qo() {
-  pkg which "$@"
+  if cmd="$(command -v -- "$@")"; then
+    pkg which "$cmd"
+  else
+    pkg which "$@"
+  fi
 }
 
 pkgng_Qp() {

--- a/lib/portage.sh
+++ b/lib/portage.sh
@@ -33,7 +33,11 @@ portage_Ql() {
 
 portage_Qo() {
   if [[ -x '/usr/bin/equery' ]]; then
-    equery belongs "$@"
+    if cmd="$(command -v -- "$@")"; then
+      equery belongs "$cmd"
+    else
+      equery belongs "$@"
+    fi
   else
     _error "'gentoolkit' package is required to perform this operation."
   fi

--- a/lib/sun_tools.sh
+++ b/lib/sun_tools.sh
@@ -31,7 +31,11 @@ sun_tools_Ql() {
 }
 
 sun_tools_Qo() {
-  $GREP "$@" /var/sadm/install/contents
+  if cmd="$(command -v -- "$@")"; then
+    $GREP "$cmd" /var/sadm/install/contents
+  else
+    $GREP "$@" /var/sadm/install/contents
+  fi
 }
 
 sun_tools_Qs() {

--- a/lib/swupd.sh
+++ b/lib/swupd.sh
@@ -22,7 +22,11 @@ swupd_Qk() {
 }
 
 swupd_Qo() {
-  swupd search "$@"
+  if cmd="$(command -v -- "$@")"; then
+    swupd search "$cmd"
+  else
+    swupd search "$@"
+  fi
 }
 
 swupd_Qs() {

--- a/lib/tazpkg.sh
+++ b/lib/tazpkg.sh
@@ -119,7 +119,11 @@ tazpkg_Ss() {
 }
 
 tazpkg_Qo() {
-  tazpkg search-pkgname "$@"
+  if cmd="$(command -v -- "$@")"; then
+    tazpkg search-pkgname "$cmd"
+  else
+    tazpkg search-pkgname "$@"
+  fi
 }
 
 tazpkg_U() {

--- a/lib/yum.sh
+++ b/lib/yum.sh
@@ -40,7 +40,11 @@ yum_Ql() {
 }
 
 yum_Qo() {
-  rpm -qf "$@"
+  if cmd="$(command -v -- "$@")"; then
+    rpm -qf "$cmd"
+  else
+    rpm -qf "$@"
+  fi
 }
 
 yum_Qp() {

--- a/lib/zypper.sh
+++ b/lib/zypper.sh
@@ -39,7 +39,11 @@ zypper_Qm() {
 }
 
 zypper_Qo() {
-  rpm -qf "$@"
+  if cmd="$(command -v -- "$@")"; then
+    rpm -qf "$cmd"
+  else
+    rpm -qf "$@"
+  fi
 }
 
 zypper_Qp() {

--- a/tests/dpkg.txt
+++ b/tests/dpkg.txt
@@ -46,6 +46,9 @@ ou ^/usr/bin/apt-key$
 in -Qo /bin/bash
 ou ^bash: /bin/bash$
 
+in -Qo bash
+ou ^bash: /bin/bash$
+
 # Search for pattern in installed package (names + descriptions)
 in -Qs bash
 ou ^bash.+Bourne

--- a/tests/slitaz40.txt
+++ b/tests/slitaz40.txt
@@ -32,6 +32,9 @@ ou not implemented
 in -Qo /bin/busybox
 ou ^busybox
 
+in -Qo busybox
+ou ^busybox
+
 in ! echo Y | pacman -S htop
 ou htop.+ is installed.
 


### PR DESCRIPTION
Operation `Qo` will try with binary searching before staring the default query. This speeds up a bit: The following commands yield the same result

```
$ pacapt -Qo bash
$ pacapt -Qo /bin/bash
```