### PR TITLE
Add apk -Qe

### DIFF
--- a/lib/apk.sh
+++ b/lib/apk.sh
@@ -35,14 +35,7 @@ apk_Q() {
 }
 
 apk_Qe() {
-  packages_marked_to_install="$(cat /etc/apk/world)"
-  installed_packages="$(apk info)"
-
-  while read -r L; do
-    echo "$installed_packages" | grep -Eo "^$L$"
-  done << EOF
-$packages_marked_to_install
-EOF
+  apk info | grep -x -f /etc/apk/world
 }
 
 apk_Qi() {

--- a/lib/apk.sh
+++ b/lib/apk.sh
@@ -34,6 +34,17 @@ apk_Q() {
   esac
 }
 
+apk_Qe() {
+  packages_marked_to_install="$(cat /etc/apk/world)"
+  installed_packages="$(apk info)"
+
+  while read -r L; do
+    echo "$installed_packages" | grep -Eo "^$L$"
+  done << EOF
+$packages_marked_to_install
+EOF
+}
+
 apk_Qi() {
   if [ "$#" -eq 0 ]; then
     # shellcheck disable=SC2046

--- a/tests/apk.txt
+++ b/tests/apk.txt
@@ -87,6 +87,28 @@ in clear
 in ! command -v screen
 ou empty
 
+# List explicitly installed packages
+in -Qe | grep -o wget
+ou empty
+
+in -S wget
+in -Qe
+ou ^wget$
+ou ^alpine-conf$
+ou ^alpine-baselayout$
+
+in -R wget
+in clear
+in -Qe | grep -o wget
+ou empty
+
+in ! echo "wget" >> /etc/apk/world
+in -Qe | grep -o wget
+ou empty
+in ! sed -i '$ d' /etc/apk/world
+in ! cat /etc/apk/world | grep -o wget
+ou empty
+
 # Clean cache
 in ! ls /var/cache/apk/
 ou ^installed$

--- a/tests/apk.txt
+++ b/tests/apk.txt
@@ -106,7 +106,7 @@ in ! echo "wget" >> /etc/apk/world
 in -Qe | grep -o wget
 ou empty
 in ! sed -i '$ d' /etc/apk/world
-in ! cat /etc/apk/world | grep -o wget
+in ! grep -o wget /etc/apk/world
 ou empty
 
 # Clean cache


### PR DESCRIPTION
It seems that Alpine Linux has documentation about [how to handle explicit installed packages](https://docs.alpinelinux.org/user-handbook/0.1a/Working/apk.html#_world). Note that with this implementation, a manual change in the `/etc/apk/world` file is not enough to consider it installed.