### PR TITLE
Add yum tests; fix yum package dependency queries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,12 @@ jobs:
     - uses: actions/checkout@v2
     - run: make tests TESTS=apk
 
+  yum:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: make tests TESTS=yum
+
   others:
     runs-on: ubuntu-latest
     steps:

--- a/lib/dpkg.sh
+++ b/lib/dpkg.sh
@@ -45,10 +45,7 @@ dpkg_Qe() {
 }
 
 dpkg_Qk() {
-  if ! command -v debsums > /dev/null 2>&1; then
-    _die "pacapt: debsums binary does not exist in system."
-  fi
-
+  _require_programs debsums
   debsums "$@"
 }
 
@@ -122,9 +119,7 @@ dpkg_R() {
 }
 
 dpkg_Sg() {
-  if ! command -v tasksel > /dev/null 2>&1; then
-    _die "pacapt: tasksel binary does not exist in system."
-  fi
+  _require_programs tasksel
   
   if [ $# -gt 0 ]; then
     tasksel --task-packages "$@"

--- a/lib/yum.sh
+++ b/lib/yum.sh
@@ -83,10 +83,7 @@ yum_R() {
 }
 
 yum_Si() {
-  if ! command -v repoquery > /dev/null 2>&1; then
-    _die "pacapt: repoquery binary does not exist in system."
-  fi
-
+  _require_programs repoquery
   repoquery --requires --resolve "$@"
 }
 
@@ -128,9 +125,6 @@ yum_U() {
 }
 
 yum_Sii() {
-  if ! command -v repoquery > /dev/null 2>&1; then
-    _die "pacapt: repoquery binary does not exist in system."
-  fi
-
+  _require_programs repoquery
   repoquery --installed --whatrequires "$@"
 }

--- a/lib/yum.sh
+++ b/lib/yum.sh
@@ -83,7 +83,11 @@ yum_R() {
 }
 
 yum_Si() {
-  yum info "$@"
+  if ! command -v repoquery > /dev/null 2>&1; then
+    _die "pacapt: repoquery binary does not exist in system."
+  fi
+
+  repoquery --requires --resolve "$@"
 }
 
 yum_Suy() {
@@ -124,5 +128,9 @@ yum_U() {
 }
 
 yum_Sii() {
-  yum resolvedep "$@"
+  if ! command -v repoquery > /dev/null 2>&1; then
+    _die "pacapt: repoquery binary does not exist in system."
+  fi
+
+  repoquery --installed --whatrequires "$@"
 }

--- a/tests/dpkg.txt
+++ b/tests/dpkg.txt
@@ -115,7 +115,7 @@ ou ^Status: deinstall
 
 # Verify package files
 in -Qk apt
-ou ^:: pacapt: debsums binary does not exist in system\.$
+ou requires 'debsums' but the tool is not found\.$
 in -S --noconfirm debsums
 in -Qk apt
 ou /usr/bin/apt.+OK
@@ -126,7 +126,7 @@ in -R --noconfirm debsums
 
 # Package groups
 in -Sg
-ou ^:: pacapt: tasksel binary does not exist in system\.$
+ou requires 'tasksel' but the tool is not found\.$
 in -S --noconfirm tasksel
 in -Sg
 ou ^u (print-server|ubuntu-desktop|manual)

--- a/tests/yum.txt
+++ b/tests/yum.txt
@@ -1,0 +1,136 @@
+#!/bin/sh
+
+# Purpose : Testing script for yum support
+# Author  : Álvaro Mondéjar
+# License : MIT
+
+im centos:7 centos:8
+
+in -P
+ou available operations:.*( [Q][ ilos])+
+
+# Get installed packages
+in -Qq
+ou ^rpm$
+in -Q
+ou ^rpm [0-9]+\.[0-9]+\.?[0-9]*$
+
+# Get packages information
+in -Qi
+ou ^Name\s+: rpm$
+ou ^Version\s+: [0-9]+\.[0-9]+\.?[0-9]*$
+
+# Get package information
+in -Qi rpm
+ou ^Name\s+: rpm$
+ou ^Version\s+: [0-9]+\.[0-9]+\.?[0-9]*$
+
+# Get locally installed package
+in -Qs rpm
+ou ^rpm [0-9]+\.[0-9]+\.?[0-9]*$
+in -Qqs rpm
+ou ^rpm$
+
+# Get package files
+in -Ql rpm
+ou ^(/usr)?/bin/rpm$
+
+# Get package from file
+in -Qo rpm
+ou ^rpm-.+\.x86_64$
+in -Qo "$(command -v rpm)"
+ou ^rpm-.+\.x86_64$
+
+# Show package changelog
+in -Qc rpm
+ou ^*\s.+[0-9]$
+
+# List packages with available updates
+in -Qu
+ou ^[a-z\-]+\.x86_64.+(baseos|updates)$
+in -Sy
+ou ^[a-z\-]+\.x86_64.+(baseos|updates)$
+
+# Get installed packages unavailable in repos
+in -Qm
+ou ^(Last metadata expiration check|Loaded plugins)
+
+# Install package
+in ! command -v wget
+ou empty
+in -S --noconfirm wget
+ou ^Installing:$
+ou ^ wget\s+x86_64
+ou ^Installed:$
+in ! command -v wget
+ou ^(/usr)?/bin/wget$
+
+# Remove package
+in -R --noconfirm wget
+ou ^Removing:$
+ou ^ wget\s+x86_64
+ou ^Removed:$
+in ! command -v wget
+ou empty
+
+in -S --noconfirm wget
+in ! command -v wget
+ou ^(/usr)?/bin/wget$
+in -Rs --noconfirm wget
+ou ^Removing:$
+ou ^ wget\s+x86_64
+ou ^Removed:$
+in ! command -v wget
+ou empty
+
+# Update
+in -Su
+ou ^Up(dat|grad)ing:$
+in -Suy
+ou ^[a-z\-]+\.x86_64.+(baseos|updates)$
+
+# Search packages
+in -Ss wget
+ou ^wget\.x86_64
+
+# NOTE: dependencies queries require repoquery (included in yum-utils)
+in -S --noconfirm yum-utils
+in clear
+in ! command -v repoquery
+ou ^(/usr)?/bin/repoquery$
+
+# Get information from local package file
+in ! repoquery --location nano
+ou ^http.+\.rpm$
+in ! curl -sL "$(repoquery --location nano 2>/dev/null)" -o /tmp/nano-package.rpm
+ou empty
+in ! [ -f /tmp/nano-package.rpm ] || echo not found
+ou empty
+in -Qp /tmp/nano-package.rpm
+ou ^nano-.+\.x86_64$
+
+# Install package using local file
+in ! command -v nano
+ou empty
+in -U --noconfirm /tmp/nano-package.rpm
+ou ^Installing:$
+ou ^ nano\s+x86_64
+ou ^Installed:$
+in ! command -v nano
+ou ^(/usr)?/bin/nano$
+
+# Cache cleaning
+in -Sc
+ou ^[0-9]+( metadata)? files removed$
+in -Scc
+ou ^[0-9]+( package)? files removed$
+in -Sccc
+ou ^([0-9]+ files removed|Cleaning repos:)
+
+# Get dependencies
+in -Si yum
+ou ^(dnf|rpm)-
+
+# Get reverse dependencies
+in -Sii rpm
+ou ^rpm-libs-


### PR DESCRIPTION
 - Add yum tests under Centos7 and Centos8.
 - Fix yum `Si` and `Sii` operations, which currently aren't retrieving package dependencies, using [repoquery](https://www.man7.org/linux/man-pages/man1/repoquery.1.html).