### PR TITLE
Add pkgng tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,3 +79,19 @@ jobs:
         ln -s pacapt.dev pacman
         cd tests/
         make test_homebrew
+
+  pkgng:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: vmactions/freebsd-vm@v0.1.5
+      with:
+        usesh: true
+        prepare: pkg install -y bash ruby git
+        run: |
+          set -x
+          make pacapt.dev
+          ln -s pacapt.dev pacman
+          export PATH="$(pwd -P):$PATH"
+          cd tests/
+          make test_pkgng

--- a/lib/pkgng.sh
+++ b/lib/pkgng.sh
@@ -98,7 +98,8 @@ pkgng_Scc() {
 }
 
 pkgng_S() {
-  if [ "$_TOPT" = "fetch" ]; then
+  # shellcheck disable=SC2153
+  if [ "$_EOPT" = "fetch" ]; then
     pkg fetch "$@"
   else
     pkg install "$@"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,3 +43,12 @@ test_homebrew:
 	@mkdir -pv tmp
 	@ruby -n ../bin/gen_tests.rb < homebrew.txt > tmp/homebrew.sh
 	@cd tmp && MSG_PREFIX=":: [homebrew] " sh homebrew.sh
+
+# test_pkgng:
+# test_pkgng: Execute FreeBSD tests within MacOS provided by Github-actions
+.PHONY: test_pkgng
+test_pkgng:
+	@set -u && echo $$CI >/dev/null
+	@mkdir -pv tmp
+	@ruby -n ../bin/gen_tests.rb < pkgng.txt > tmp/pkgng.sh
+	@cd tmp && MSG_PREFIX=":: [pkgng] " sh pkgng.sh

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -51,4 +51,5 @@ test_pkgng:
 	@set -u && echo $$CI >/dev/null
 	@mkdir -pv tmp
 	@ruby -n ../bin/gen_tests.rb < pkgng.txt > tmp/pkgng.sh
+	@pkg remove -y bash || true
 	@cd tmp && MSG_PREFIX=":: [pkgng] " sh pkgng.sh

--- a/tests/pkgng.txt
+++ b/tests/pkgng.txt
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+# Purpose : Testing script for pkgng support
+# Author  : Álvaro Mondéjar
+# License : MIT
+
+# NOTE: Must be executed in a FreeBSD distribution
+
+im freebsd
+
+# Get installed packages
+in -Qq
+ou ^(pkg|git|ruby)
+in -Q
+ou ^(pkg|git|ruby)
+
+# Get packages information
+in -Qi
+ou ^pkg-[0-9]+\.[0-9]+\.?[0-9]*\s+Package manager$
+
+# Get package information
+in -Qi pkg
+ou ^Name\s+: pkg$
+ou ^Version\s+: [0-9]+\.[0-9]+\.?[0-9]*$
+
+# Get package files
+in -Ql pkg
+ou ^pkg-[0-9]+\.[0-9]+\.?[0-9]*:$
+ou ^\s+/usr/local/sbin/pkg$
+
+# Get dependencies
+in -Si nginx
+ou ^Name\s+: nginx$
+ou ^Version\s+: [0-9]+\.[0-9]+\.?[0-9]*
+ou ^Shared Libs required:$
+
+# Search package
+in -Ss nano
+ou ^nano-[0-9]+\.[0-9]+\.?[0-9]*
+ou ^rubygem-nanoc-[0-9]+\.[0-9]+\.?[0-9]*
+
+# Update
+in -Sy
+ou ^All repositories are up to date\.$
+
+# Upgrade
+in -Su
+ou ^Your packages are up to date\.$
+in -Syu
+ou ^All repositories are up to date\.$
+ou ^Your packages are up to date\.$
+
+# Install package
+in ! command -v nano
+ou empty
+in -S --noconfirm nano
+ou ^New packages to be INSTALLED:$
+in ! command -v nano
+ou ^/usr/local/bin/nano$
+
+# Remove package
+in -R --noconfirm nano
+ou ^Installed packages to be REMOVED:$
+in ! nano
+ou not found
+
+in -S --noconfirm nano
+in clear
+in -R --noconfirm nano
+ou ^Installed packages to be REMOVED:$
+
+# Fetch package
+in -Sw nano
+ou ^Number of packages to be fetched: 1$
+
+# Clean cache
+in -Sc --noconfirm
+ou ^The following package files will be deleted:$
+in -Scc
+ou ^Nothing to do.$


### PR DESCRIPTION
- Add `pkgng` tests for FreeBSD using [vmactions/freebsd-vm](https://github.com/vmactions/freebsd-vm) ([~1-3 minutes slower than `dpkg`](https://github.com/mondeja/pacapt/actions/runs/1008949370))
- Fix `-Sw` operation (fetch)
