### PR TITLE
Prevent network errors in yum and dnf tests

### DIFF
--- a/tests/dnf.txt
+++ b/tests/dnf.txt
@@ -86,7 +86,7 @@ ou ^Available Packages$
 # Get information from local package file
 in ! dnf repoquery --location nano
 ou ^http.+\.rpm$
-in ! curl -sL "$(dnf repoquery --location nano 2>/dev/null | head -n 1)" -o /tmp/nano-package.rpm
+in ! curl -sL "$(dnf repoquery --location nano 2>/dev/null | head -n 1)" -o /tmp/nano-package.rpm --connect-timeout 5 --max-time 30 --retry 5 --retry-delay 0 --retry-max-time 60
 ou empty
 in ! [ -f /tmp/nano-package.rpm ] || echo not found
 ou empty

--- a/tests/yum.txt
+++ b/tests/yum.txt
@@ -102,7 +102,7 @@ ou ^(/usr)?/bin/repoquery$
 # Get information from local package file
 in ! repoquery --location nano
 ou ^http.+\.rpm$
-in ! curl -sL "$(repoquery --location nano 2>/dev/null | head -n 1)" -o /tmp/nano-package.rpm
+in ! curl -sL "$(repoquery --location nano 2>/dev/null | head -n 1)" -o /tmp/nano-package.rpm --connect-timeout 5 --max-time 30 --retry 5 --retry-delay 0 --retry-max-time 60
 ou empty
 in ! [ -f /tmp/nano-package.rpm ] || echo not found
 ou empty


### PR DESCRIPTION
The dnf tests suite [fails sometimes](https://github.com/mondeja/pacapt/runs/3017729736?check_suite_focus=true#step:3:323) because a file is not downloaded, so retrying the connection I think that should be enough for preventing that noise.