### PR TITLE
Add sun_tools tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,3 +95,20 @@ jobs:
           export PATH="$(pwd -P):$PATH"
           cd tests/
           make test_pkgng
+
+  sun_tools:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: vmactions/solaris-vm@v0.0.3
+      with:
+        run: |
+          set -x
+          /opt/csw/bin/pkgutil -U
+          /opt/csw/bin/pkgutil -a git ruby
+          /opt/csw/bin/pkgutil -y -i git ruby20
+          make pacapt.dev
+          ln -s pacapt.dev pacman
+          export PATH="$(pwd -P):$PATH"
+          cd tests/
+          make test_sun_tools

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,14 +100,12 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Build pacapt and tests
+      run: make pacapt.dev && mkdir -pv tests/tmp/ && cd tests && ruby -n ../bin/gen_tests.rb < sun_tools.txt > tmp/sun_tools.sh
     - uses: vmactions/solaris-vm@v0.0.3
       with:
         run: |
           set -x
-          /opt/csw/bin/pkgutil -U
-          /opt/csw/bin/pkgutil -a git ruby
-          /opt/csw/bin/pkgutil -y -i git ruby20
-          make pacapt.dev
           ln -s pacapt.dev pacman
           export PATH="$(pwd -P):$PATH"
           cd tests/

--- a/bin/check.sh
+++ b/bin/check.sh
@@ -84,7 +84,7 @@ _check_POSIX_files() {
   export SHELLCHECK_SHELL="sh"
   while (( $# )); do
     if awk 'NR==1' < "$1" \
-      | grep -Eiqe '^#!/usr/bin/env sh' ;
+      | grep -iq '^#!/usr/bin/env sh' ;
     then
       _check_file "$1" || return 1
     # We only care POSIX issue for files under `lib/`

--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -30,11 +30,11 @@ fi
 : "${GREP:=grep}"     # Need to update on SunOS
 : "${AWK:=awk}"       # Need to update on SunOS
 
-if [ "$(uname)" = "SunOS" ]; then
-  # ggrep (GNU-grep) is required in SunOS to build and test because the default
-  # implementation of grep in SunOS doesn't support the options `-E` and `-e` 
-  GREP=ggrep
-  AWK=nawk
+# At compile time, `_sun_tools_init` is not yet defined.
+if [[ -f "lib/sun_tools.sh" ]]; then
+  # shellcheck disable=1091
+  source "lib/sun_tools.sh" :
+  _sun_tools_init || true
 fi
 
 export GREP AWK VERSION PACAPT_STATS
@@ -116,7 +116,7 @@ library_files() {
 }
 
 library_POSIX_ready() {
-  $GREP -Eqie '#!/usr/bin/env sh' -- "$@"
+  "$GREP" -qi '#!/usr/bin/env sh' -- "$@"
 }
 
 ########################################################################

--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -30,11 +30,11 @@ fi
 : "${GREP:=grep}"     # Need to update on SunOS
 : "${AWK:=awk}"       # Need to update on SunOS
 
-# At compile time, `_sun_tools_init` is not yet defined.
-if [[ -f "lib/sun_tools.sh" ]]; then
-  # shellcheck disable=1091
-  source "lib/sun_tools.sh" :
-  _sun_tools_init || true
+if [ "$(uname)" = "SunOS" ]; then
+  # ggrep (GNU-grep) is required in SunOS to build and test because the default
+  # implementation of grep in SunOS doesn't support the options `-E` and `-e` 
+  GREP=ggrep
+  AWK=nawk
 fi
 
 export GREP AWK VERSION PACAPT_STATS
@@ -116,7 +116,7 @@ library_files() {
 }
 
 library_POSIX_ready() {
-  grep -Eqie '#!/usr/bin/env sh' -- "$@"
+  $GREP -Eqie '#!/usr/bin/env sh' -- "$@"
 }
 
 ########################################################################

--- a/bin/gen_tests.rb
+++ b/bin/gen_tests.rb
@@ -31,6 +31,12 @@ BEGIN {
   puts ""
   puts "set -u"
   puts ""
+  puts ": \"${GGREP:=grep}\""
+  puts ""
+  puts "if [ \"$(uname)\" = \"SunOS\" ]; then"
+  puts "  GGREP=ggrep"
+  puts "fi"
+  puts ""
   #
   # Just send message to STDERR
   #
@@ -107,10 +113,10 @@ elsif gs = $_.to_s.match(/^ou(.*)/)
   puts "N_TEST=$(( N_TEST + 1 ))"
   puts "if [ -n \"${F_TMP:-}\" ]; then"
   if expected.empty? or expected == "empty"
-    puts "  ret=\"$(grep -Ec '.+' $F_TMP)\""
+    puts "  ret=\"$(\"$GGREP\" -Ec '.+' $F_TMP)\""
     puts "  if [ -z \"$ret\" ] || [ \"$ret\" -ge 1 ]; then"
   else
-    puts "  ret=\"$(grep -Ec \"#{expected}\" $F_TMP)\""
+    puts "  ret=\"$(\"$GGREP\" -Ec \"#{expected}\" $F_TMP)\""
     puts "  if [ -z \"$ret\" ] || [ \"$ret\" -eq 0 ]; then"
   end
   puts "    _fail Expected \"#{expected}\""

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -59,7 +59,4 @@ test_pkgng:
 .PHONY: test_sun_tools
 test_sun_tools:
 	@set -u && echo $$CI >/dev/null
-	@mkdir -pv tmp
-	@ruby -n ../bin/gen_tests.rb < sun_tools.txt > tmp/sun_tools.sh
-	@echo y | pkgrm CSWgit || true
 	cd tmp && MSG_PREFIX=":: [sun_tools] " sh sun_tools.sh

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -53,3 +53,13 @@ test_pkgng:
 	@ruby -n ../bin/gen_tests.rb < pkgng.txt > tmp/pkgng.sh
 	@pkg remove -y bash || true
 	@cd tmp && MSG_PREFIX=":: [pkgng] " sh pkgng.sh
+
+# test_sun_tools:
+# test_sun_tools: Execute SunOS tests within MacOS provided by Github-actions
+.PHONY: test_sun_tools
+test_sun_tools:
+	@set -u && echo $$CI >/dev/null
+	@mkdir -pv tmp
+	@ruby -n ../bin/gen_tests.rb < sun_tools.txt > tmp/sun_tools.sh
+	@echo y | pkgrm CSWgit || true
+	cd tmp && MSG_PREFIX=":: [sun_tools] " sh sun_tools.sh

--- a/tests/sun_tools.txt
+++ b/tests/sun_tools.txt
@@ -10,20 +10,20 @@ im solaris
 
 # Get packages information
 in -Qi
-ou PKGINST:\s+CSWcacertificates
-ou PKGINST:\s+CSWruby20
+ou PKGINST:\s+CSWpkgutil
+ou PKGINST:\s+BRCMbnx
 
 # Get locally installed package
-in -Qs ruby
-ou ^application CSWruby20
+in -Qs pkgutil
+ou ^application CSWpkgutil
 
 # Get installed packages
 in -Q
-ou ^application CSWbash
+ou ^application CSWpkgutil
 
-in -Q CSWbash
-ou ^application CSWbash bash
+in -Q CSWpkgutil
+ou ^application CSWpkgutil pkgutil
 
 in -Qq
-ou ^application CSWbash
+ou ^application CSWpkgutil
 

--- a/tests/sun_tools.txt
+++ b/tests/sun_tools.txt
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Purpose : Testing script for sun_tools support
+# Author  : Álvaro Mondéjar
+# License : MIT
+
+# NOTE: Must be executed in a Solaris (SunOS) distribution
+
+im solaris
+
+# Get packages information
+in -Qi
+ou PKGINST:\s+CSWcacertificates
+ou PKGINST:\s+CSWruby20
+
+# Get locally installed package
+in -Qs ruby
+ou ^application CSWruby20
+
+# Get installed packages
+in -Q
+ou ^application CSWbash
+
+in -Q CSWbash
+ou ^application CSWbash bash
+
+in -Qq
+ou ^application CSWbash
+


### PR DESCRIPTION
> You can see the latest CI run [here](https://github.com/mondeja/pacapt/actions/runs/1015781139).

- The test suite is slow (~~\~25 min~~ ~16 min).
- ~~I'm not running the `sun_tools` init function at build time because in the build process `grep` needs the option `-E` included in `ggrep` (GNU-grep), but at runtime only needs the default `grep` implementation in SunOS (see [helps of both binaries](https://github.com/mondeja/pacapt/runs/3022140738?check_suite_focus=true#step:3:3958)).~~

I'm thinking on split the tests between different workflow files using the [`push/pull_request.paths`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths) option of Github Actions to only execute those test suites affected for the proposed changes, but it would be in another PR. What do you think?