### PR TITLE
Faster CI sun_tools test suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,6 +102,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build pacapt and tests
       run: make pacapt.dev && mkdir -pv tests/tmp/ && cd tests && ruby -n ../bin/gen_tests.rb < sun_tools.txt > tmp/sun_tools.sh
+    - uses: actions/cache@v2
+      with:
+        key: sol-11_4
+        path: |
+          sol-11_4.ova
     - uses: mondeja/solaris-vm-action@v1
       with:
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,11 +102,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build pacapt and tests
       run: make pacapt.dev && mkdir -pv tests/tmp/ && cd tests && ruby -n ../bin/gen_tests.rb < sun_tools.txt > tmp/sun_tools.sh
-    - uses: vmactions/solaris-vm@v0.0.3
+    - uses: mondeja/solaris-vm-action@v1
       with:
         run: |
           set -x
-          ln -s pacapt.dev pacman
-          export PATH="$(pwd -P):$PATH"
+          mv pacapt.dev /bin/pacman
           cd tests/
           make test_sun_tools


### PR DESCRIPTION
Replaces current CI `sun_tools` test suite virtual machine creation system with [mondeja/solaris-vm-action](https://github.com/mondeja/solaris-vm-action). The performance increase is sill improvable, but now takes ~9 min against previous ~16 min.