### PR TITLE
lib/portage: Error fix

### DIFF
--- a/lib/portage.sh
+++ b/lib/portage.sh
@@ -76,7 +76,7 @@ portage_Rs() {
 }
 
 portage_R() {
-  emerge --depclean "@"
+  emerge --depclean "$@"
 }
 
 portage_Si() {


### PR DESCRIPTION
Thanks to a good catch from https://github.com/icy/pacapt/commit/7cfa046010d90a132ba396ff37e34728ccdfbfcb