### PR TITLE
{pkgng,macports}: Missing shift when -w is used

### DIFF
--- a/lib/00_core.sh
+++ b/lib/00_core.sh
@@ -237,8 +237,10 @@ _translate_all() {
 
   local_debug="$(_translate_debug)" || return 1
   local_noconfirm="$(_translate_noconfirm)" || return 1
-  local_args="$(_translate_w)" || return 1
 
+  # WARNING: Order does matter, see also
+  #   https://github.com/icy/pacapt/pull/219#issuecomment-1006079629
+  local_args="$(_translate_w)" || return 1
   local_args="${local_args}${local_noconfirm:+ }${local_noconfirm}"
   local_args="${local_args}${local_debug:+ }${local_debug}"
 

--- a/lib/apk.sh
+++ b/lib/apk.sh
@@ -116,8 +116,8 @@ apk_S() {
   case ${_EOPT} in
     # Download only
     ("fetch") shift
-              apk fetch $_TOPT -- "$@" ;;
-          (*) apk add   $_TOPT -- "$@" ;;
+              apk fetch $_TOPT "$@" ;;
+          (*) apk add   $_TOPT "$@" ;;
   esac
 }
 

--- a/lib/macports.sh
+++ b/lib/macports.sh
@@ -82,6 +82,7 @@ macports_Scc() {
 
 macports_S() {
   if [ "$_TOPT" = "fetch" ]; then
+    shift
     port patch "$@"
   else
     port install "$@"

--- a/lib/pkgng.sh
+++ b/lib/pkgng.sh
@@ -100,6 +100,7 @@ pkgng_Scc() {
 pkgng_S() {
   # shellcheck disable=SC2153
   if [ "$_EOPT" = "fetch" ]; then
+    shift
     pkg fetch "$@"
   else
     pkg install "$@"


### PR DESCRIPTION
apk, macports and dpkgpng all use their own action "fetch"
when "-w" (download-only) option is specified. Because the
method is invoked with $_EOPT as part of the argument
(in our case, $_EOPT == fetch), we need to remove the part
before processing the remained parts.

Fix #214