### PR TITLE
Use macos-10.15 instead of macos-latest in VMs workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
         make test_homebrew
 
   pkgng:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - uses: vmactions/freebsd-vm@v0.1.5
@@ -121,7 +121,7 @@ jobs:
           make test_pkgng
 
   sun_tools:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - name: Build pacapt and tests


### PR DESCRIPTION
Fixes #221

Just for the records: VirtualBox could be at some point re-added to macos-11 Github machines. There is a closed PR that could track this at https://github.com/actions/virtual-environments/pull/4010